### PR TITLE
Fixes in CAAccessControlFilter.java

### DIFF
--- a/certificate-authority/src/main/java/eu/arrowhead/core/certificate_authority/security/CAAccessControlFilter.java
+++ b/certificate-authority/src/main/java/eu/arrowhead/core/certificate_authority/security/CAAccessControlFilter.java
@@ -15,8 +15,8 @@ public class CAAccessControlFilter extends CoreSystemAccessControlFilter {
 
 	// =================================================================================================
 	// members
-	private static final CoreSystem[] allowedCoreSystemsForTrustedKeyHandling = { CoreSystem.ONBOARDING_CONTROLLER };
-	private static final CoreSystem[] allowedCoreSystemsForCertificateHandling = { CoreSystem.ONBOARDING_CONTROLLER };
+	private static final CoreSystem[] allowedCoreSystemsForTrustedKeyHandling = { CoreSystem.ONBOARDING_CONTROLLER, CoreSystem.DEVICE_REGISTRY, CoreSystem.SYSTEM_REGISTRY };
+	private static final CoreSystem[] allowedCoreSystemsForCertificateHandling = { CoreSystem.ONBOARDING_CONTROLLER, CoreSystem.DEVICE_REGISTRY, CoreSystem.SYSTEM_REGISTRY };
 
 	// =================================================================================================
 	// assistant methods
@@ -50,7 +50,7 @@ public class CAAccessControlFilter extends CoreSystemAccessControlFilter {
 			final CoreSystem[] allowedCoreSystems, final String requestTarget) {
 
 		boolean result = checkIfClientIsAnAllowedCoreSystemNoException(clientCN, cloudCN,
-				allowedCoreSystemsForTrustedKeyHandling, requestTarget);
+				allowedCoreSystems, requestTarget);
 
 
 		if (!result) {


### PR DESCRIPTION
Fixed to allow Device Registry and System Registry for certificate and trusted key handling.