### PR TITLE
Fix start scripts

### DIFF
--- a/scripts/start_coresystems.bat
+++ b/scripts/start_coresystems.bat
@@ -1,5 +1,6 @@
 @ECHO OFF
 
+SET version="4.3.0"
 SET parent_path=%~dp0
 cd %parent_path%
 
@@ -8,40 +9,40 @@ SET time_to_sleep=10
 echo Starting Core Systems... Service initializations usually need around 20 seconds.
 
 cd ..\serviceregistry\target
-START "serviceregistry" /B "cmd /c javaw -jar arrowhead-serviceregistry-4.2.0.jar > sout_sr.log 2>&1"
+START "serviceregistry" /B "cmd /c javaw -jar arrowhead-serviceregistry-%version%.jar > sout_sr.log 2>&1"
 echo Service Registry started
 timeout /t %time_to_sleep% /nobreak > NUL
 
 cd ..\..\authorization\target
-START "" /B "cmd /c javaw -jar arrowhead-authorization-4.2.0.jar > sout_auth.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-authorization-%version%.jar > sout_auth.log 2>&1"
 echo Authorization started
 
 cd ..\..\gateway\target
-START "" /B "cmd /c javaw -jar arrowhead-gateway-4.2.0.jar > sout_gateway.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-gateway-%version%.jar > sout_gateway.log 2>&1"
 echo Gateway started
 
 cd ..\..\eventhandler\target
-START "" /B "cmd /c javaw -jar arrowhead-eventhandler-4.2.0.jar > sout_eventhandler.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-eventhandler-%version%.jar > sout_eventhandler.log 2>&1"
 echo Event Handler started
 
 cd ..\..\datamanager\target
-START "" /B "cmd /c javaw -jar arrowhead-datamanager-4.1.3.jar > sout_datamanager.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-datamanager-%version%.jar > sout_datamanager.log 2>&1"
 echo DataManager started
 
 cd ..\..\gatekeeper\target
-START "" /B "cmd /c javaw -jar arrowhead-gatekeeper-4.2.0.jar > sout_gk.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-gatekeeper-%version%.jar > sout_gk.log 2>&1"
 echo Gatekeeper started
 
 cd ..\..\orchestrator\target
-START "" /B "cmd /c javaw -jar arrowhead-orchestrator-4.2.0.jar > sout_orch.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-orchestrator-%version%.jar > sout_orch.log 2>&1"
 echo Orchestrator started
 
 cd ..\..\choreographer\target
-START "" /B "cmd /c javaw -jar arrowhead-choreographer-4.2.0.jar > sout_choreographer.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-choreographer-%version%.jar > sout_choreographer.log 2>&1"
 echo Choreographer started
 
 cd ..\..\certificate-authority\target
-START "" /B "cmd /c javaw -jar arrowhead-certificate-authority-4.2.0.jar > sout_ca.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-certificate-authority-%version%.jar > sout_ca.log 2>&1"
 echo Certificate Authority started
 
 cd %parent_path%

--- a/scripts/start_coresystems_local.bat
+++ b/scripts/start_coresystems_local.bat
@@ -2,6 +2,7 @@
 
 REM Gatekeeper and Gateway are not started for local clouds
 
+SET version="4.3.0"
 SET parent_path=%~dp0
 cd %parent_path%
 
@@ -10,29 +11,33 @@ SET time_to_sleep=10
 echo Starting Core Systems... Service initializations usually need around 20 seconds.
 
 cd ..\serviceregistry\target
-START "serviceregistry" /B "cmd /c javaw -jar arrowhead-serviceregistry-4.2.0.jar > sout_sr.log 2>&1"
+START "serviceregistry" /B "cmd /c javaw -jar arrowhead-serviceregistry-%version%.jar > sout_sr.log 2>&1"
 echo Service Registry started
 timeout /t %time_to_sleep% /nobreak > NUL
 
 cd ..\..\authorization\target
-START "" /B "cmd /c javaw -jar arrowhead-authorization-4.2.0.jar > sout_auth.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-authorization-%version%.jar > sout_auth.log 2>&1"
 echo Authorization started
 
 REM cd ..\..\eventhandler\target
-REM START "" /B "cmd /c javaw -jar arrowhead-eventhandler-4.2.0.jar > sout_eventhandler.log 2>&1"
+REM START "" /B "cmd /c javaw -jar arrowhead-eventhandler-%version%.jar > sout_eventhandler.log 2>&1"
 REM echo Event Handler started
 
 REM cd ..\..\datamanager\target
-REM START "" /B "cmd /c javaw -jar arrowhead-datamanager-4.1.3.jar > sout_datamanager.log 2>&1"
+REM START "" /B "cmd /c javaw -jar arrowhead-datamanager-%version%.jar > sout_datamanager.log 2>&1"
 REM echo DataManager started
 
 cd ..\..\orchestrator\target
-START "" /B "cmd /c javaw -jar arrowhead-orchestrator-4.2.0.jar > sout_orch.log 2>&1"
+START "" /B "cmd /c javaw -jar arrowhead-orchestrator-%version%.jar > sout_orch.log 2>&1"
 echo Orchestrator started
 
-cd ..\..\certificate-authority\target
-START "" /B "cmd /c javaw -jar arrowhead-certificate-authority-4.2.0.jar > sout_ca.log 2>&1"
-echo Certificate Authority started
+REM cd ..\..\choreographer\target
+REM START "" /B "cmd /c javaw -jar arrowhead-choreographer-%version%.jar > sout_choreographer.log 2>&1"
+REM echo Choreographer started
+
+REM cd ..\..\certificate-authority\target
+REM START "" /B "cmd /c javaw -jar arrowhead-certificate-authority-%version%.jar > sout_ca.log 2>&1"
+REM echo Certificate Authority started
 
 cd %parent_path%
 

--- a/scripts/start_coresystems_local.sh
+++ b/scripts/start_coresystems_local.sh
@@ -30,6 +30,10 @@ cd ../../orchestrator/target
 nohup java -jar $(find . -maxdepth 1 -name arrowhead-orchestrator-\*.jar | sort | tail -n1) &> sout_orch.log &
 echo Orchestrator started
 
-cd ../../certificate-authority/target
-nohup java -jar $(find . -maxdepth 1 -name arrowhead-certificate-authority-\*.jar | sort | tail -n1) &> sout_ca.log &
-echo Certificate Authority started
+#cd ../../choreographer/target
+#nohup java -jar $(find . -maxdepth 1 -name arrowhead-choreographer-\*.jar | sort | tail -n1) &> sout_choreographer.log &
+#echo Choreographer started
+
+#cd ../../certificate-authority/target
+#nohup java -jar $(find . -maxdepth 1 -name arrowhead-certificate-authority-\*.jar | sort | tail -n1) &> sout_ca.log &
+#echo Certificate Authority started


### PR DESCRIPTION
- add version variable to `start_*.bat` files (and set them to 4.3.0)
- set manadatory core systems as default ones in `start_coresystems_local.*` files

Master branch was choosen intentionally, because this is a fix for the current version and have no affect on the core system's code. 