### PR TITLE
Corrected Certificate authority image name

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
 
   certificateauthority:
     container_name: certificateauthority
-    image: svetlint/certificateauthority:latest
+    image: svetlint/certificate-authority:latest
     depends_on:
       - mysql
     volumes:


### PR DESCRIPTION
Hi, 
I'm trying out the updated docker images. 
The certificate authority seems to have a naming error. 
I think this should fix it.

Best regards