### PR TITLE
Upgrade lombok to version 1.18.24

### DIFF
--- a/hawkbit-configuration-manager/pom.xml
+++ b/hawkbit-configuration-manager/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.16</version>
+			<version>1.18.24</version>
 			<scope>provided</scope>
 		</dependency>
 


### PR DESCRIPTION
These changes update lombok to version 1.18.24 to be compatible with newer Java versions. Closes #414.