### PR TITLE
Exclude snakeyaml dependency

### DIFF
--- a/hawkbit-configuration-manager/pom.xml
+++ b/hawkbit-configuration-manager/pom.xml
@@ -45,6 +45,10 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-starter-logging</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -98,11 +102,6 @@
 			<artifactId>jose4j</artifactId>
 			<version>0.6.5</version>
 		</dependency>
-		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.32</version>
-		</dependency>
 		
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -152,6 +151,12 @@
 			<artifactId>mockserver-netty</artifactId>
 			<version>5.11.1</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.mock-server</groupId>


### PR DESCRIPTION
This PR excludes the snakeyaml dependency as a temporary solution.