### PR TITLE
fix: missing serialVersionUID for all serializable classes

### DIFF
--- a/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/CreateInstanceRequest.java
+++ b/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/CreateInstanceRequest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(value = "request")
 public class CreateInstanceRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @ApiModelProperty(required = true, value = "The name of the new instance", dataType = "string")
     private String name;

--- a/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/CreateSensorRequest.java
+++ b/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/CreateSensorRequest.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(value = "request")
 public class CreateSensorRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     @ApiModelProperty(required = true, value = "Name of the sensor", dataType = "string", example = "MyTemperatureSensor")
     private String name;

--- a/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/GamsInstanceDto.java
+++ b/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/GamsInstanceDto.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 public class GamsInstanceDto implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final String name;
     private final String uid;

--- a/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/PublishSensorDataRequest.java
+++ b/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/PublishSensorDataRequest.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 public class PublishSensorDataRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private String timestamp;
     private Object data;

--- a/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/SensorDataDto.java
+++ b/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/SensorDataDto.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 public class SensorDataDto implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private String uid;
     private String address;

--- a/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/SensorDto.java
+++ b/gams/src/main/java/eu/arrowhead/core/gams/rest/dto/SensorDto.java
@@ -102,4 +102,6 @@ public class SensorDto implements Serializable {
                 .add("timeUnit=" + timeUnit)
                 .toString();
     }
+    
+    private static final long serialVersionUID = 1L;    
 }


### PR DESCRIPTION
##### Motivation:

In Project: there exists some serializable classes but they do not contain any serialVersionUID field. The compiler generates one by default in such scenarios, but the generated id is dependent on compiler implementation and may cause unwanted problems during deserialization.

##### The Role of serialVersionUID:

The primary role of serialVersionUID is to provide version control during deserialization. When we deserialize an object, the JVM checks whether the serialVersionUID of the serialized data matches the serialVersionUID of the class in the current classpath. If they match, the deserialization proceeds without issues. However, if they do not match, program can  encounter InvalidClassException.

As, serialVersionUID servers the purpose of version control of class during serialization-deserialization, without a serialVersionUID, we risk breaking backward compatibility when changes are made to classes, which can lead to unexpected issues and errors during deserialization.

So, any change(addition or removal of any field) in any classes in the future(if it is needed to be changed) will cause issue with all previous instances if no serialVersionUID is provided.

##### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.